### PR TITLE
Issue 17: Upgrade to Espressif IDF 4.2

### DIFF
--- a/software/firmware/source/SoftRF/src/driver/WiFi.cpp
+++ b/software/firmware/source/SoftRF/src/driver/WiFi.cpp
@@ -31,7 +31,7 @@ void WiFi_fini()    {}
 #include "GNSS.h"
 #include "EEPROM.h"
 #include "WiFi.h"
-#include "tcpip_adapter.h"
+#include "esp_netif.h"
 #include "../TrafficHelper.h"
 #include "RF.h"
 #include "../ui/Web.h"


### PR DESCRIPTION
A change required for an upgrade of Espressif IDF 4.1 to 4.2.

I don't know which version of Espressif SoftRF currently requires.