### PR TITLE
fix IN frequency to work with GXAirCom and Skytraxx

### DIFF
--- a/software/firmware/source/libraries/OGN/freqplan.h
+++ b/software/firmware/source/libraries/OGN/freqplan.h
@@ -58,7 +58,7 @@ class FreqPlan
 #endif
           break;
         case RF_BAND_IN:
-          { BaseFreq=866000000; ChanSepar=200000; Channels= 1; MaxTxPower = 30; } // India
+          { BaseFreq=866200000; ChanSepar=250000; Channels= 1; MaxTxPower = 30; } // India
           break;
         case RF_BAND_IL:
           { BaseFreq=916200000; ChanSepar=200000; Channels= 1; MaxTxPower = 30; } // Israel


### PR DESCRIPTION
This fixes the IN frequency. Now SoftRF show up on GXAirCom and Skytraxx.

![Screenshot at 2024-09-27 11-31-37](https://github.com/user-attachments/assets/728449ba-c1d4-420c-94d3-fb1a99aefc83)
